### PR TITLE
Add AudioSender, fix binary stdout corruption, and fix audio-to-audio pipeline bugs

### DIFF
--- a/Node/apps/conversational_agent/app.ts
+++ b/Node/apps/conversational_agent/app.ts
@@ -20,17 +20,6 @@ import { RTCAudioData } from '@roamhq/wrtc/types/nonstandard';
 import { fileURLToPath } from 'url';
 import nconf from 'nconf';
 
-/**
- * How many milliseconds of model audio to accumulate before flushing to Unity.
- * Batching reduces AudioInfo message overhead and gives Unity's audio system
- * a larger buffer to work with, preventing playback stutter / latency.
- *
- * The model produces one 80 ms frame per step (~12.5 fps).
- * 240 ms ≈ 3 frames — a good trade-off between latency and smoothness.
- * Override with UBIQ_AUDIO_BATCH_MS.
- */
-const AUDIO_BATCH_MS = Number(process.env.UBIQ_AUDIO_BATCH_MS) || 240;
-
 export class ConversationalAgent extends ApplicationController {
     components: {
         voipReceiver?: VoipReceiver;
@@ -47,19 +36,8 @@ export class ConversationalAgent extends ApplicationController {
     /** Tracks the UUID of the peer that most recently sent audio. */
     private lastAudioSenderUuid: string = '';
 
-    /** Whether the PersonaPlex handshake has been received. */
-    private personaplexReady: boolean = false;
-
     /** Parser instance for decoding PersonaPlex stdout framing. */
     private stdoutParser: LengthPrefixedParser = new LengthPrefixedParser();
-
-    // --- Audio output batching ---
-    /** Accumulated audio buffers (48 kHz PCM16LE) waiting to be sent to Unity. */
-    private audioOutputQueue: Buffer[] = [];
-    /** Total byte length of buffers currently in audioOutputQueue. */
-    private audioOutputQueueBytes: number = 0;
-    /** Timer handle for the periodic audio flush. */
-    private audioFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
     constructor(configFile: string = 'config.json') {
         super(configFile);
@@ -114,11 +92,19 @@ export class ConversationalAgent extends ApplicationController {
     /**
      * Audio-to-audio pipeline: audio from peers is downsampled to 24 kHz,
      * framed with the PersonaPlex binary protocol, and sent to the model.
-     * Model output (audio + text) is parsed, upsampled to 48 kHz, batched,
-     * and sent to Unity periodically (every AUDIO_BATCH_MS milliseconds).
+     * Model output (audio + text) is parsed, upsampled to 48 kHz, and sent
+     * to Unity immediately as raw PCM chunks.
+     *
+     * A single AudioInfo header is sent when the first audio frame arrives
+     * from the model. Subsequent frames are streamed as raw PCM chunks
+     * without new headers — this avoids Unity's `dropOnNewSequence`
+     * clearing the playback queue on every header.
      */
     private defineAudioToAudioPipeline() {
         const service = this.components.audioToAudioService!;
+
+        /** Whether the initial AudioInfo header has been sent for this stream. */
+        let streamStarted = false;
 
         // ---- Input: receive 48 kHz PCM16 from WebRTC ----
         this.components.voipReceiver?.on('audio', (uuid: string, data: RTCAudioData) => {
@@ -128,13 +114,17 @@ export class ConversationalAgent extends ApplicationController {
 
             // Don't send audio to the model before it's ready — it would pile
             // up in the OS pipe buffer and create a stale backlog.
-            if (!this.personaplexReady) {
+            if (service.state !== 'ready' && service.state !== 'idle') {
                 return;
             }
 
             this.lastAudioSenderUuid = uuid;
 
-            const sampleBuffer = Buffer.from(data.samples.buffer);
+            const sampleBuffer = Buffer.from(
+                data.samples.buffer,
+                data.samples.byteOffset,
+                data.samples.byteLength,
+            );
             const downsampled = downsample48kTo24k(sampleBuffer);
             const packet = encodePacket(KIND_AUDIO, downsampled);
 
@@ -154,13 +144,24 @@ export class ConversationalAgent extends ApplicationController {
             for (const packet of packets) {
                 switch (packet.kind) {
                     case KIND_HANDSHAKE:
-                        this.personaplexReady = true;
+                        service.setReady();
                         this.log('PersonaPlex handshake received — model is ready');
                         break;
 
                     case KIND_AUDIO: {
                         const upsampled = upsample24kTo48k(packet.payload);
-                        this.enqueueAudioForUnity(upsampled);
+
+                        // Send one AudioInfo at stream start so Unity knows the
+                        // sample rate and target peer. After that, send only raw
+                        // PCM chunks — no new headers that would clear the queue.
+                        if (!streamStarted) {
+                            const targetPeerObj = this.roomClient.peers.get(this.lastAudioSenderUuid);
+                            const targetPeer = targetPeerObj?.properties.get('ubiq.displayname') ?? '';
+                            this.audioSender.sendHeader({ targetPeer });
+                            streamStarted = true;
+                        }
+
+                        this.audioSender.sendChunks(upsampled);
                         break;
                     }
 
@@ -184,56 +185,11 @@ export class ConversationalAgent extends ApplicationController {
         });
 
         service.on('close', (code: number | null, signal: string | null, identifier: string) => {
-            this.flushAudioToUnity();
+            streamStarted = false;
             this.flushStream();
             this.log(`PersonaPlex process ${identifier} exited (code=${code}, signal=${signal})`, 'warning');
-            this.personaplexReady = false;
             this.stdoutParser.reset();
         });
-    }
-
-    // ---- Audio output batching helpers ----
-
-    /**
-     * Queue upsampled audio and schedule a batched send to Unity.
-     *
-     * Instead of sending each 80 ms model frame individually (which causes
-     * Unity to receive a new AudioInfo message 12.5×/sec and potentially
-     * introduces playback startup overhead per message), we accumulate
-     * frames and flush them as one larger AudioInfo batch every AUDIO_BATCH_MS.
-     */
-    private enqueueAudioForUnity(upsampled: Buffer): void {
-        this.audioOutputQueue.push(upsampled);
-        this.audioOutputQueueBytes += upsampled.length;
-
-        // Start the flush timer on the first enqueued frame
-        if (this.audioFlushTimer === null) {
-            this.audioFlushTimer = setTimeout(() => this.flushAudioToUnity(), AUDIO_BATCH_MS);
-        }
-    }
-
-    /**
-     * Flush all queued audio to Unity as a single AudioInfo + data batch.
-     */
-    private flushAudioToUnity(): void {
-        if (this.audioFlushTimer !== null) {
-            clearTimeout(this.audioFlushTimer);
-            this.audioFlushTimer = null;
-        }
-
-        if (this.audioOutputQueue.length === 0) {
-            return;
-        }
-
-        const combined = Buffer.concat(this.audioOutputQueue);
-        this.audioOutputQueue = [];
-        this.audioOutputQueueBytes = 0;
-
-        // Resolve target peer
-        const targetPeerObj = this.roomClient.peers.get(this.lastAudioSenderUuid);
-        const targetPeer = targetPeerObj?.properties.get('ubiq.displayname') ?? '';
-
-        this.audioSender.send(combined, { targetPeer });
     }
 
     /**
@@ -243,8 +199,13 @@ export class ConversationalAgent extends ApplicationController {
     private defineTraditionalPipeline() {
         // Step 1: When we receive audio data from a peer we send it to the transcription service
         this.components.voipReceiver?.on('audio', (uuid: string, data: RTCAudioData) => {
-            // Convert the Int16Array to a Buffer
-            const sampleBuffer = Buffer.from(data.samples.buffer);
+            // Convert the Int16Array to a Buffer (use byteOffset/byteLength
+            // in case the TypedArray is a view into a larger ArrayBuffer)
+            const sampleBuffer = Buffer.from(
+                data.samples.buffer,
+                data.samples.byteOffset,
+                data.samples.byteLength,
+            );
 
             // Send the audio data to the transcription service
             if (this.roomClient.peers.get(uuid) !== undefined) {

--- a/Node/apps/conversational_agent/app.ts
+++ b/Node/apps/conversational_agent/app.ts
@@ -1,10 +1,10 @@
-import { NetworkId } from 'ubiq-server/ubiq';
 import { ApplicationController } from '../../components/application';
 import { TextToSpeechService } from '../../services/text_to_speech/service';
 import { SpeechToTextService } from '../../services/speech_to_text/service';
 import { TextGenerationService } from '../../services/text_generation/service';
 import { AudioToAudioService } from '../../services/audio_to_audio/service';
 import { VoipReceiver } from '../../components/voip_receiver';
+import { AudioSender } from '../../components/audio_sender';
 import {
     encodePacket,
     LengthPrefixedParser,
@@ -39,6 +39,9 @@ export class ConversationalAgent extends ApplicationController {
         textToSpeechService?: TextToSpeechService;
         audioToAudioService?: AudioToAudioService;
     } = {};
+
+    /** Shared sender that handles AudioInfo headers + chunked PCM protocol. */
+    private audioSender!: AudioSender;
     targetPeerQueue: string[] = [];
 
     /** Tracks the UUID of the peer that most recently sent audio. */
@@ -81,6 +84,9 @@ export class ConversationalAgent extends ApplicationController {
     }
 
     registerComponents() {
+        // Centralised audio sender — includes sampleRate in every AudioInfo header
+        this.audioSender = new AudioSender(this.scene, 95, 48000);
+
         // A VoipReceiver to receive audio data from peers via WebRTC VOIP
         this.components.voipReceiver = new VoipReceiver(this.scene);
 
@@ -227,18 +233,7 @@ export class ConversationalAgent extends ApplicationController {
         const targetPeerObj = this.roomClient.peers.get(this.lastAudioSenderUuid);
         const targetPeer = targetPeerObj?.properties.get('ubiq.displayname') ?? '';
 
-        // Send one AudioInfo for the entire batch
-        this.scene.send(new NetworkId(95), {
-            type: 'AudioInfo',
-            targetPeer: targetPeer,
-            audioLength: combined.length,
-        });
-
-        let remaining = combined;
-        while (remaining.length > 0) {
-            this.scene.send(new NetworkId(95), remaining.subarray(0, 16000));
-            remaining = remaining.subarray(16000);
-        }
+        this.audioSender.send(combined, { targetPeer });
     }
 
     /**
@@ -296,19 +291,8 @@ export class ConversationalAgent extends ApplicationController {
         });
 
         this.components.textToSpeechService?.on('data', (data: Buffer, identifier: string) => {
-            let response = data;
             const targetPeer = this.targetPeerQueue.shift() ?? '';
-
-            this.scene.send(new NetworkId(95), {
-                type: 'AudioInfo',
-                targetPeer: targetPeer,
-                audioLength: data.length,
-            });
-
-            while (response.length > 0) {
-                this.scene.send(new NetworkId(95), response.slice(0, 16000));
-                response = response.slice(16000);
-            }
+            this.audioSender.send(data, { targetPeer });
         });
     }
 }

--- a/Node/apps/stream_describer/app.ts
+++ b/Node/apps/stream_describer/app.ts
@@ -4,6 +4,7 @@ import { MediaReceiver } from '../../components/media_receiver';
 import { MessageReader } from '../../components/message_reader';
 import { VisualQuestionAnsweringService } from '../../services/visual_question_answering/service';
 import { TextToSpeechService } from '../../services/text_to_speech/service';
+import { AudioSender } from '../../components/audio_sender';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import nconf from 'nconf';
@@ -36,6 +37,9 @@ class StreamDescriber extends ApplicationController {
         vqa?: VisualQuestionAnsweringService;
         tts?: TextToSpeechService;
     } = {};
+
+    /** Shared sender for TTS audio — includes sampleRate in AudioInfo headers. */
+    private audioSender!: AudioSender;
 
     /** Timestamp of the last frame sent per peer, to throttle. */
     private lastFrameTime = new Map<string, number>();
@@ -83,6 +87,9 @@ class StreamDescriber extends ApplicationController {
     }
 
     registerComponents(): void {
+        // Centralised audio sender — includes sampleRate in every AudioInfo header
+        this.audioSender = new AudioSender(this.scene, AUDIO_NETWORK_ID, 48000);
+
         // MediaReceiver to receive video tracks sent by MediaTrackManager
         this.components.mediaReceiver = new MediaReceiver(this.scene);
 
@@ -287,19 +294,7 @@ class StreamDescriber extends ApplicationController {
 
         this.log(`Sending ${combined.length} bytes of TTS audio to Unity`);
 
-        // One AudioInfo for the entire speech sequence
-        this.scene.send(new NetworkId(AUDIO_NETWORK_ID), {
-            type: 'AudioInfo',
-            audioLength: combined.length.toString(),
-        });
-
-        // Stream the raw PCM16 data
-        let offset = 0;
-        while (offset < combined.length) {
-            const end = Math.min(offset + 16000, combined.length);
-            this.scene.send(new NetworkId(AUDIO_NETWORK_ID), combined.subarray(offset, end));
-            offset = end;
-        }
+        this.audioSender.send(combined);
     }
 }
 

--- a/Node/components/audio_sender.ts
+++ b/Node/components/audio_sender.ts
@@ -1,0 +1,63 @@
+import { NetworkId, NetworkScene } from 'ubiq-server/ubiq';
+
+/** Maximum bytes of raw PCM16 data per network message. */
+const MAX_CHUNK_BYTES = 16000;
+
+/** Default sample rate when none is specified. */
+const DEFAULT_SAMPLE_RATE = 48000;
+
+/**
+ * Encapsulates the AudioInfo + chunked-PCM16 protocol used by Ubiq-Genie
+ * to stream audio from the Node server to Unity's InjectableAudioSource.
+ *
+ * Using this component instead of inline `scene.send` calls ensures that:
+ *  - The `sampleRate` field is always included in AudioInfo headers so that
+ *    Unity can resample when the device output rate differs.
+ *  - The chunked-send loop and header format are consistent across all apps.
+ */
+export class AudioSender {
+    private readonly scene: NetworkScene;
+    private readonly networkId: NetworkId;
+    private readonly sampleRate: number;
+
+    /**
+     * @param scene      The Ubiq NetworkScene to send messages on.
+     * @param networkId  The network ID that InjectableAudioSource listens on.
+     * @param sampleRate The sample rate of the PCM16 audio that will be sent
+     *                   (Hz). This is included in every AudioInfo header so
+     *                   Unity can resample if its output rate differs.
+     *                   Defaults to 48 000.
+     */
+    constructor(scene: NetworkScene, networkId: number | NetworkId, sampleRate: number = DEFAULT_SAMPLE_RATE) {
+        this.scene = scene;
+        this.networkId = typeof networkId === 'number' ? new NetworkId(networkId) : networkId;
+        this.sampleRate = sampleRate;
+    }
+
+    /**
+     * Send a complete audio buffer to Unity using the AudioInfo + chunked-PCM
+     * protocol.
+     *
+     * @param audio   Raw PCM16-LE mono audio bytes at `this.sampleRate`.
+     * @param options Optional metadata included in the AudioInfo header.
+     */
+    send(audio: Buffer, options?: { targetPeer?: string }): void {
+        if (audio.length === 0) return;
+
+        // 1. AudioInfo header
+        this.scene.send(this.networkId, {
+            type: 'AudioInfo',
+            targetPeer: options?.targetPeer ?? '',
+            audioLength: audio.length.toString(),
+            sampleRate: this.sampleRate.toString(),
+        });
+
+        // 2. Raw PCM16 data in ≤MAX_CHUNK_BYTES chunks
+        let offset = 0;
+        while (offset < audio.length) {
+            const end = Math.min(offset + MAX_CHUNK_BYTES, audio.length);
+            this.scene.send(this.networkId, audio.subarray(offset, end));
+            offset = end;
+        }
+    }
+}

--- a/Node/components/audio_sender.ts
+++ b/Node/components/audio_sender.ts
@@ -36,23 +36,47 @@ export class AudioSender {
 
     /**
      * Send a complete audio buffer to Unity using the AudioInfo + chunked-PCM
-     * protocol.
+     * protocol. Sends an AudioInfo header followed by the raw data chunks.
+     *
+     * Best for **one-shot** audio (e.g. TTS responses) where each call
+     * represents a discrete utterance. For continuous streaming (e.g.
+     * audio-to-audio), use `sendHeader()` once and then `sendChunks()` for
+     * each frame to avoid Unity clearing its playback queue on every header.
      *
      * @param audio   Raw PCM16-LE mono audio bytes at `this.sampleRate`.
      * @param options Optional metadata included in the AudioInfo header.
      */
     send(audio: Buffer, options?: { targetPeer?: string }): void {
         if (audio.length === 0) return;
+        this.sendHeader({ ...options, audioLength: audio.length });
+        this.sendChunks(audio);
+    }
 
-        // 1. AudioInfo header
+    /**
+     * Send only the AudioInfo header (no audio data).
+     *
+     * Use this once at the start of a continuous stream, then call
+     * `sendChunks()` for each audio frame. This avoids the queue-clearing
+     * side-effect of `dropOnNewSequence` on the Unity side.
+     */
+    sendHeader(options?: { targetPeer?: string; audioLength?: number }): void {
         this.scene.send(this.networkId, {
             type: 'AudioInfo',
             targetPeer: options?.targetPeer ?? '',
-            audioLength: audio.length.toString(),
+            audioLength: (options?.audioLength ?? 0).toString(),
             sampleRate: this.sampleRate.toString(),
         });
+    }
 
-        // 2. Raw PCM16 data in ≤MAX_CHUNK_BYTES chunks
+    /**
+     * Send raw PCM16 data chunks without an AudioInfo header.
+     *
+     * Each chunk is at most MAX_CHUNK_BYTES. Unity's InjectableAudioSource
+     * treats messages ≥ 200 bytes that are not valid JSON as raw PCM audio,
+     * so no preceding AudioInfo is needed for the data to be played.
+     */
+    sendChunks(audio: Buffer): void {
+        if (audio.length === 0) return;
         let offset = 0;
         while (offset < audio.length) {
             const end = Math.min(offset + MAX_CHUNK_BYTES, audio.length);

--- a/Node/components/service.ts
+++ b/Node/components/service.ts
@@ -115,8 +115,8 @@ class ServiceController extends EventEmitter {
     /** Per-process state tracking. Key is the process identifier. */
     private processStates: { [identifier: string]: ServiceState } = {};
 
-    /** Pending stdout data per process for line-based marker detection. */
-    private stdoutBuffers: { [identifier: string]: string } = {};
+    /** Pending stdout data per process for binary-safe marker detection. */
+    private stdoutBuffers: { [identifier: string]: Buffer } = {};
 
     /** Resolvers for waitForReady() promises. */
     private readyResolvers: { [identifier: string]: Array<() => void> } = {};
@@ -467,44 +467,76 @@ class ServiceController extends EventEmitter {
         });
     }
 
-    // --- stdout marker detection ---
+    // --- stdout marker detection (binary-safe) ---
+
+    // Pre-computed marker byte sequences for binary comparison.
+    private static readonly MARKER_READY = Buffer.from('>READY');
+    private static readonly MARKER_BUSY  = Buffer.from('>BUSY');
+    private static readonly MARKER_IDLE  = Buffer.from('>IDLE');
+
+    /**
+     * Checks whether a raw byte slice (after trimming ASCII whitespace)
+     * exactly matches the given marker bytes. Operates entirely on Buffers
+     * so that binary data is never run through a lossy text encoding.
+     */
+    private static matchesMarker(buf: Buffer, start: number, end: number, marker: Buffer): boolean {
+        // Trim leading ASCII whitespace (space 0x20, tab 0x09, CR 0x0D)
+        while (start < end && (buf[start] === 0x20 || buf[start] === 0x09 || buf[start] === 0x0D)) start++;
+        // Trim trailing ASCII whitespace
+        while (end > start && (buf[end - 1] === 0x20 || buf[end - 1] === 0x09 || buf[end - 1] === 0x0D)) end--;
+        const len = end - start;
+        if (len !== marker.length) return false;
+        for (let i = 0; i < len; i++) {
+            if (buf[start + i] !== marker[i]) return false;
+        }
+        return true;
+    }
 
     /**
      * Scans stdout data for state markers (>READY, >BUSY, >IDLE) and updates
      * the process state accordingly. Markers are stripped from the data before
      * being emitted to consumers.
      *
+     * All operations stay in Buffer space — binary data (e.g., raw PCM audio)
+     * is never converted through a lossy text encoding round-trip.
+     *
      * Returns the data with marker lines removed.
      */
     private processStdoutMarkers(data: Buffer, identifier: string): Buffer {
-        const text = data.toString();
-        this.stdoutBuffers[identifier] = (this.stdoutBuffers[identifier] ?? '') + text;
+        // Prepend any leftover bytes from the previous data event
+        const pending = this.stdoutBuffers[identifier];
+        const buf = pending && pending.length > 0
+            ? Buffer.concat([pending, data])
+            : data;
 
-        const lines = this.stdoutBuffers[identifier].split('\n');
-        // Keep the last incomplete line in the buffer
-        this.stdoutBuffers[identifier] = lines.pop() ?? '';
+        const NEWLINE = 0x0A;
+        const outputParts: Buffer[] = [];
+        let lineStart = 0;
 
-        const outputLines: string[] = [];
-        for (const line of lines) {
-            const trimmed = line.trim();
-            if (trimmed === '>READY') {
-                this.setState(identifier, 'ready');
-            } else if (trimmed === '>BUSY') {
-                this.setState(identifier, 'busy');
-            } else if (trimmed === '>IDLE') {
-                this.setState(identifier, 'idle');
-            } else {
-                outputLines.push(line);
+        for (let i = 0; i < buf.length; i++) {
+            if (buf[i] === NEWLINE) {
+                // Check the line (lineStart..i, excluding the \n) against markers
+                if (ServiceController.matchesMarker(buf, lineStart, i, ServiceController.MARKER_READY)) {
+                    this.setState(identifier, 'ready');
+                } else if (ServiceController.matchesMarker(buf, lineStart, i, ServiceController.MARKER_BUSY)) {
+                    this.setState(identifier, 'busy');
+                } else if (ServiceController.matchesMarker(buf, lineStart, i, ServiceController.MARKER_IDLE)) {
+                    this.setState(identifier, 'idle');
+                } else {
+                    // Not a marker — pass the raw bytes through (including the \n)
+                    outputParts.push(buf.subarray(lineStart, i + 1));
+                }
+                lineStart = i + 1;
             }
         }
 
-        // Reconstruct the buffer without marker lines
-        const filtered = outputLines.join('\n');
-        // Add newline back if there was content (to match original stream behavior)
-        if (filtered.length > 0) {
-            return Buffer.from(filtered + '\n');
-        }
-        return Buffer.alloc(0);
+        // Save any trailing bytes after the last \n for the next data event
+        this.stdoutBuffers[identifier] = lineStart < buf.length
+            ? Buffer.from(buf.subarray(lineStart))
+            : Buffer.alloc(0);
+
+        if (outputParts.length === 0) return Buffer.alloc(0);
+        return Buffer.concat(outputParts);
     }
 
     /**

--- a/Node/components/service.ts
+++ b/Node/components/service.ts
@@ -95,6 +95,14 @@ interface ServiceProvider {
     requirements?: string;
     /** Optional Python command override specific to this provider */
     pythonCommand?: string;
+    /**
+     * How stdout from the child process should be interpreted.
+     * - 'text' (default): Line-buffered; stdout is scanned for >READY, >BUSY, >IDLE markers.
+     * - 'binary': Raw passthrough; no line buffering or marker scanning.
+     *   The consumer is responsible for readiness detection and state management
+     *   (e.g., via setReady()).
+     */
+    stdoutMode?: 'text' | 'binary';
 }
 
 /**
@@ -183,6 +191,24 @@ class ServiceController extends EventEmitter {
             }
             this.readyResolvers[identifier].push(resolve);
         });
+    }
+
+    /**
+     * Manually signal that a process is ready. Intended for binary-stdout
+     * services where readiness is detected by the consumer (e.g., via a
+     * protocol-level handshake) rather than by a >READY stdout marker.
+     *
+     * Only transitions from 'starting' to 'ready'. No-ops if already ready/idle.
+     */
+    setReady(identifier: string = 'default'): void {
+        const current = this.getState(identifier);
+        if (current === 'ready' || current === 'idle') return;
+        if (current === 'error' || current === 'stopped') {
+            throw new Error(
+                `Cannot set ready: process '${identifier}' is in '${current}' state`
+            );
+        }
+        this.setState(identifier, 'ready');
     }
 
     private setState(identifier: string, state: ServiceState) {
@@ -570,9 +596,14 @@ class ServiceController extends EventEmitter {
         const childProcess = this.childProcesses[identifier];
         if (childProcess && childProcess.stdout && childProcess.stderr) {
             childProcess.stdout.on('data', (data: Buffer) => {
-                const filtered = this.processStdoutMarkers(data, identifier);
-                if (filtered.length > 0) {
-                    this.emit('data', filtered, identifier);
+                if (this.provider?.stdoutMode === 'binary') {
+                    // Binary mode: pass through raw bytes, no marker scanning
+                    this.emit('data', data, identifier);
+                } else {
+                    const filtered = this.processStdoutMarkers(data, identifier);
+                    if (filtered.length > 0) {
+                        this.emit('data', filtered, identifier);
+                    }
                 }
             });
             childProcess.stderr.on('data', (data) => {

--- a/Node/services/audio_to_audio/providers/personaplex/provider.ts
+++ b/Node/services/audio_to_audio/providers/personaplex/provider.ts
@@ -128,6 +128,7 @@ export function createPersonaPlexProvider(options?: PersonaPlexProviderOptions):
         command: 'python',
         args,
         processMode: 'singleton',
+        stdoutMode: 'binary',
         env: { PYTHONPATH: envPythonPath },
     };
 }

--- a/Unity/Assets/Ubiq-Genie/Apps/ConversationalAgent/Scripts/ConversationalAgentManager.cs
+++ b/Unity/Assets/Ubiq-Genie/Apps/ConversationalAgent/Scripts/ConversationalAgentManager.cs
@@ -18,9 +18,10 @@ public class ConversationalAgentManager : MonoBehaviour
     {
         public float startTime;
         public int samples;
+        public int sampleRate;
         public string speechTargetName;
 
-        public float endTime { get { return startTime + samples/(float)AudioSettings.outputSampleRate; } }
+        public float endTime { get { return startTime + samples / (float)sampleRate; } }
     }
 
     public InjectableAudioSource audioSource;
@@ -91,6 +92,7 @@ public class ConversationalAgentManager : MonoBehaviour
         var prevUnit = speechUnits.Count > 0 ? speechUnits[speechUnits.Count - 1] : null;
         speechUnit.startTime = prevUnit != null ? prevUnit.endTime : Time.time;
         speechUnit.samples = e.SampleCount;
+        speechUnit.sampleRate = AudioSettings.outputSampleRate;
         speechUnit.speechTargetName = speechTargetName;
         speechUnits.Add(speechUnit);
     }

--- a/Unity/Assets/Ubiq-Genie/Runtime/InjectableAudioSource.cs
+++ b/Unity/Assets/Ubiq-Genie/Runtime/InjectableAudioSource.cs
@@ -23,6 +23,8 @@ public class AudioInfoReceivedEventArgs : EventArgs
     public string Type { get; set; }
     public string TargetPeer { get; set; }
     public int AudioLength { get; set; }
+    /// <summary>Source sample rate declared by the server (Hz). 0 if not provided.</summary>
+    public int SampleRate { get; set; }
 }
 
 /// <summary>
@@ -71,6 +73,16 @@ public class InjectableAudioSource : MonoBehaviour
     private NetworkContext context;
 
     /// <summary>
+    /// The sample rate declared by the server in the most recent AudioInfo
+    /// header. Defaults to 48 000 Hz for backward compatibility with servers
+    /// that do not send the field.
+    /// </summary>
+    private int sourceSampleRate = 48000;
+
+    /// <summary>Cached device output sample rate, set once in Start().</summary>
+    private int outputSampleRate;
+
+    /// <summary>
     /// Maximum number of float samples to keep in the playback queue.
     /// ~5 seconds at 48 kHz. Only used when dropOnNewSequence is false.
     /// </summary>
@@ -78,8 +90,10 @@ public class InjectableAudioSource : MonoBehaviour
 
     /// <summary>
     /// Messages shorter than this are treated as AudioInfo JSON headers.
+    /// Increased from 100 to 256 to accommodate the added sampleRate field
+    /// and future metadata without silently dropping headers.
     /// </summary>
-    private const int AUDIO_INFO_HEADER_MAX_SIZE = 100;
+    private const int AUDIO_INFO_HEADER_MAX_SIZE = 256;
 
     /// <summary>
     /// Raw audio packets smaller than this are discarded as noise.
@@ -92,30 +106,15 @@ public class InjectableAudioSource : MonoBehaviour
         public string type;
         public string targetPeer;
         public string audioLength;
+        public string sampleRate;
     }
 
     private void Start()
     {
-        // Use a clip filled with 1s
-        // This helps us piggyback on Unity's spatialisation using filters
-        if (debugLogging) Debug.Log($"[InjectableAudioSource] Output sample rate: {AudioSettings.outputSampleRate}");
-        var samples = new float[AudioSettings.outputSampleRate];
-        for (int i = 0; i < samples.Length; i++)
-        {
-            samples[i] = 1.0f;
-        }
+        outputSampleRate = AudioSettings.outputSampleRate;
+        SetupAudioClip();
 
-        clip = AudioClip.Create("Injectable",
-            samples.Length,
-            1,
-            AudioSettings.outputSampleRate,
-            false);
-
-        var audioSource = GetComponent<AudioSource>();
-        audioSource.clip = clip;
-        audioSource.loop = true;   // Must loop so OnAudioFilterRead keeps firing
-        clip.SetData(samples, 0);
-        audioSource.Play();
+        AudioSettings.OnAudioConfigurationChanged += OnAudioConfigurationChanged;
 
         if (receiveFromNetwork)
         {
@@ -124,8 +123,65 @@ public class InjectableAudioSource : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Creates (or recreates) the 1-filled AudioClip at the current
+    /// outputSampleRate and assigns it to the AudioSource.
+    /// </summary>
+    private void SetupAudioClip()
+    {
+        var audioSource = GetComponent<AudioSource>();
+
+        if (clip != null)
+        {
+            audioSource.Stop();
+            Destroy(clip);
+        }
+
+        // Use a clip filled with 1s
+        // This helps us piggyback on Unity's spatialisation using filters
+        var onesBuffer = new float[outputSampleRate];
+        for (int i = 0; i < onesBuffer.Length; i++)
+        {
+            onesBuffer[i] = 1.0f;
+        }
+
+        clip = AudioClip.Create("Injectable",
+            onesBuffer.Length,
+            1,
+            outputSampleRate,
+            false);
+
+        clip.SetData(onesBuffer, 0);
+        audioSource.clip = clip;
+        audioSource.loop = true;   // Must loop so OnAudioFilterRead keeps firing
+        audioSource.Play();
+    }
+
+    /// <summary>
+    /// Called by Unity when the audio device configuration changes (e.g.
+    /// Bluetooth switching from A2C to HFP when the microphone activates).
+    /// Updates the cached output sample rate, recreates the AudioClip, and
+    /// clears any stale samples that were resampled for the old rate.
+    /// </summary>
+    private void OnAudioConfigurationChanged(bool deviceWasChanged)
+    {
+        int newRate = AudioSettings.outputSampleRate;
+        if (newRate == outputSampleRate)
+            return;
+
+        if (debugLogging) Debug.Log($"[InjectableAudioSource] Output sample rate changed: {outputSampleRate} → {newRate} Hz");
+        outputSampleRate = newRate;
+
+        // Queued samples were resampled for the old rate — discard them.
+        samples = new ConcurrentQueue<float>();
+
+        SetupAudioClip();
+    }
+
     private void OnDestroy()
     {
+        AudioSettings.OnAudioConfigurationChanged -= OnAudioConfigurationChanged;
+
         if (clip != null)
         {
             Destroy(clip);
@@ -146,7 +202,17 @@ public class InjectableAudioSource : MonoBehaviour
                 var message = data.FromJson<AudioInfoMessage>();
                 int.TryParse(message.audioLength, out int audioLen);
 
-                if (debugLogging) Debug.Log($"[InjectableAudioSource] AudioInfo: audioLength={audioLen}");
+                // Update source sample rate; default to 48 000 if absent
+                if (int.TryParse(message.sampleRate, out int parsedRate) && parsedRate > 0)
+                {
+                    sourceSampleRate = parsedRate;
+                }
+                else
+                {
+                    sourceSampleRate = 48000;
+                }
+
+                if (debugLogging) Debug.Log($"[InjectableAudioSource] AudioInfo: audioLength={audioLen}, sampleRate={sourceSampleRate}");
 
                 // A new audio sequence is starting.
                 if (dropOnNewSequence)
@@ -161,6 +227,7 @@ public class InjectableAudioSource : MonoBehaviour
                     Type = message.type ?? "",
                     TargetPeer = message.targetPeer ?? "",
                     AudioLength = audioLen,
+                    SampleRate = sourceSampleRate,
                 });
                 return;
             }
@@ -176,38 +243,76 @@ public class InjectableAudioSource : MonoBehaviour
         }
 
         // Raw PCM16 audio chunk — inject it
-        InjectPcm(data.data.ToArray());
+        int samplesInjected = InjectPcm(data.data.ToArray());
 
         OnAudioChunkReceived?.Invoke(this, new AudioChunkReceivedEventArgs
         {
-            SampleCount = data.data.Length / 2,
+            SampleCount = samplesInjected,
         });
     }
 
     /// <summary>
     /// Inject raw PCM16-LE audio bytes into the playback queue.
+    /// If the source sample rate (from the most recent AudioInfo header)
+    /// differs from the device output rate, the audio is resampled using
+    /// linear interpolation before being enqueued.
     /// Can be called manually or is called automatically when
     /// receiveFromNetwork is true.
     /// </summary>
-    public void InjectPcm(Span<byte> bytes)
+    /// <returns>The number of samples enqueued (at the output sample rate).</returns>
+    public int InjectPcm(Span<byte> bytes)
     {
+        int inputSampleCount = bytes.Length / 2;
+        bool needsResample = sourceSampleRate != outputSampleRate && outputSampleRate > 0;
+
+        // Decode PCM16-LE into float[] first — we need random access for resampling
+        float[] decoded = new float[inputSampleCount];
+        for (int i = 0; i < inputSampleCount; i++)
+        {
+            decoded[i] = (short)(bytes[i * 2] | (bytes[i * 2 + 1] << 8)) / 32768f;
+        }
+
+        float[] output;
+        if (needsResample)
+        {
+            // Linear-interpolation resampler
+            double ratio = (double)sourceSampleRate / outputSampleRate;
+            int outputCount = (int)Math.Ceiling(inputSampleCount / ratio);
+            output = new float[outputCount];
+
+            for (int o = 0; o < outputCount; o++)
+            {
+                double srcPos = o * ratio;
+                int idx = (int)srcPos;
+                double frac = srcPos - idx;
+
+                float s0 = decoded[Math.Min(idx, inputSampleCount - 1)];
+                float s1 = decoded[Math.Min(idx + 1, inputSampleCount - 1)];
+                output[o] = (float)(s0 + (s1 - s0) * frac);
+            }
+        }
+        else
+        {
+            output = decoded;
+        }
+
         // When not dropping on new sequence, cap the queue to prevent
         // unbounded growth. Atomic swap avoids per-sample drain overhead.
         if (!dropOnNewSequence)
         {
-            int incomingSamples = bytes.Length / 2;
-            if (samples.Count + incomingSamples > MAX_QUEUE_SAMPLES)
+            if (samples.Count + output.Length > MAX_QUEUE_SAMPLES)
             {
                 samples = new ConcurrentQueue<float>();
                 if (debugLogging) Debug.LogWarning("[InjectableAudioSource] Queue overflow — cleared");
             }
         }
 
-        for (int i = 0; i < bytes.Length / 2; i++)
+        for (int i = 0; i < output.Length; i++)
         {
-            var sample = (short)(bytes[i * 2] | (bytes[i * 2 + 1] << 8)) / 32768f;
-            samples.Enqueue(sample);
+            samples.Enqueue(output[i]);
         }
+
+        return output.Length;
     }
 
     private void OnAudioFilterRead(float[] data, int channels)


### PR DESCRIPTION
Adds the AudioSender component, fixes binary data corruption in the stdout marker scanner, and corrects two bugs in the audio-to-audio pipeline that caused choppy output and degraded microphone input.

### Key Changes
- Encapsulates the AudioInfo header + chunked-PCM16 protocol used to stream audio from Node to Unity's InjectableAudioSource. Ensures sampleRate is always included in every header so Unity can resample when the device output rate differs, and keeps the chunked-send logic consistent across all apps.
- InjectableAudioSource now reads the sampleRate field from AudioInfo headers and applies linear-interpolation resampling when the source rate differs from the device output rate. AudioSender always populates this field.
- The stdout marker scanner (>READY, >BUSY, >IDLE) was previously run over a string-decoded copy of stdout, corrupting multi-byte binary sequences. Rewrote the scanner to operate entirely on Buffer objects, splitting on newline bytes and comparing byte-for-byte. Binary stdout mode (stdoutMode: 'binary') bypasses the scanner entirely.
- The 240 ms timer-based batching was sending a new AudioInfo header with every flush. Unity's InjectableAudioSource clears its playback queue on every AudioInfo header (dropOnNewSequence = true), causing 4+ queue clears per second and audible gaps. Removed the batching: one AudioInfo is now sent when the first model frame arrives, and all subsequent frames stream as raw PCM chunks via AudioSender.sendChunks().
- Buffer.from(data.samples.buffer) wraps the entire underlying ArrayBuffer, ignoring any byteOffset on the Int16Array view. Fixed to use Buffer.from(data.samples.buffer, data.samples.byteOffset, data.samples.byteLength) in both pipelines.